### PR TITLE
Nanollet: privateKeyDerivation

### DIFF
--- a/wallets.json
+++ b/wallets.json
@@ -196,7 +196,7 @@
             "mnemonicExport": [],
             "privateKeyImport": false,
             "privateKeyExport": true,
-            "privateKeyDerivation": ["blake2b"],
+            "privateKeyDerivation": ["blake2x"],
             "walletSweep": [],
             "keyStorage": ["local"],
             "fileBackup": false,


### PR DESCRIPTION
It's uses Argon2 + Blake2X (https://research.kudelskisecurity.com/2016/11/11/blake2x-unlimited-hashing/), that's not Blake2b.