### PR TITLE
Add Windows to supported operating systems of atto

### DIFF
--- a/wallets.json
+++ b/wallets.json
@@ -615,7 +615,7 @@
         "logo": "https://nanowallets.s3.eu-north-1.amazonaws.com/wallet-logos/atto.png",
         "featureComplete": true,
         "features": {
-            "platforms": ["Linux", "MacOS", "*BSD"],
+            "platforms": ["Linux", "Mac", "BSD", "Win"],
             "openSource": "https://github.com/codesoap/atto",
             "changeRepSupport": true,
             "multiAssetSupport": false,

--- a/wallets.json
+++ b/wallets.json
@@ -615,7 +615,7 @@
         "logo": "https://nanowallets.s3.eu-north-1.amazonaws.com/wallet-logos/atto.png",
         "featureComplete": true,
         "features": {
-            "platforms": ["Linux", "Mac", "BSD", "Win"],
+            "platforms": ["linux", "mac", "BSD", "win"],
             "openSource": "https://github.com/codesoap/atto",
             "changeRepSupport": true,
             "multiAssetSupport": false,


### PR DESCRIPTION
Windows is now fully supported by atto: https://github.com/codesoap/atto/releases/tag/v1.1.0.

I also changed "MacOS" to "Mac", since this seems to be more common.