### PR TITLE
Trust Wallet ledger recovery note

### DIFF
--- a/wallets.json
+++ b/wallets.json
@@ -291,7 +291,7 @@
             "qrGenerator":true,
             "authenticationMethods": ["password","biometrics"],
             "moreInformation": "https://trustwallet.com/",
-            "other": "Supports domain resolution (Unstoppable domains)"
+            "other": "Supports domain resolution (Unstoppable domains). Trust wallet does not allow ledger recovery if ledger uses a BIP39 passphrase."
         }
     },
     {


### PR DESCRIPTION
Added note about Trust Wallet not supporting ledger recovery if ledger uses BIP39